### PR TITLE
Made SendGrid email feature optional for development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,16 @@ Next follow these instructions.
 
 Follow the given instructions for Login into the app.
 
-1. You can register a new user by setting up SendGrid details in the `settings.py`, you can take a reference from [here](https://sendgrid.com/docs/for-developers/sending-email/integrating-with-the-smtp-api/)
+1. You can register a new user by making a POST request on `/api/token_auth/register/`. After this confirmation e-mail will be sent to standard output (terminal). To receive confirmation e-mail using Sendgrid see [this](#environment-variables). The content of the request must be like this:
+    ```json
+    {
+        "username":"< YOUR USERNAME >",
+        "email":"< YOUR EMAIL >",
+        "password":"< YOUR PASSWORD >",
+        "confirm_password":"< YOUR PASSWORD >"  
+    }
+    ```
+
 
 2. To create the superuser run:
    ```
@@ -85,7 +94,7 @@ Follow the given instructions for Login into the app.
 
 1. `Zulip API KEY file` - You can go [Zulip](https://anitab-org.zulipchat.com) and follow [these instructions to get your API KEY](https://zulip.com/api/api-keys#get-your-api-key). Download the file and save it in the root folder of the project with the name `download`.
 
-2. `SENDGRID_API_KEY` - Follow the given steps to create a Sendgrid API key:
+2. `SENDGRID_API_KEY` - It is optional for development. To use this variable make `DEBUG=False` in `settings.py`. Follow the given steps to create a Sendgrid API key:
 
 	1. Go to [Sendgrid's website](https://app.sendgrid.com/guide)
 	2. Navigate to Settings on the left navigation bar, and then - select API Keys.

--- a/main/settings.py
+++ b/main/settings.py
@@ -96,15 +96,18 @@ CORS_ORIGIN_WHITELIST = [
     "http://localhost:3000",
 ]
 
-SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY")
-SENDGRID_SANDBOX_MODE_IN_DEBUG = False
-SENDGRID_ECHO_TO_STDOUT = True
-EMAIL_HOST = "smtp.sendgrid.net"
-EMAIL_HOST_USER = "apikey"
-EMAIL_HOST_PASSWORD = SENDGRID_API_KEY
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+if DEBUG:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+else:
+    SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY")
+    SENDGRID_SANDBOX_MODE_IN_DEBUG = False
+    SENDGRID_ECHO_TO_STDOUT = True
+    EMAIL_HOST = "smtp.sendgrid.net"
+    EMAIL_HOST_USER = "apikey"
+    EMAIL_HOST_PASSWORD = SENDGRID_API_KEY
+    EMAIL_PORT = 587
+    EMAIL_USE_TLS = True
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 AUTH_USER_MODEL = "token_auth.User"
 


### PR DESCRIPTION
### Description

Added Console as `EMAIL_BACKEND` in `settings.py` which is the default for development to receiving the email.
Also updated the README.

Fixes #85

### Type of Change:

- Code
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
By registering a new user the confirmation e-mail is sent to the standard output (terminal).

**Screenshot**:
![email](https://user-images.githubusercontent.com/56037184/108604873-81a1eb00-73d6-11eb-9607-e2329bda4ce3.png)
 

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes