### PR TITLE
Rename OSP references to AnitaB Forms in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing Guidelines
-Welcome to contributing in **Open Source Programs**! 
+Welcome to contributing in **AnitaB Forms**! 
 
 - You can join us on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). Each active repo has its own stream. OSP stream is [#open-source-progs](https://anitab-org.zulipchat.com/#narrow/stream/237907-open-source-progs).
 - To ensure a safe, positive environment for all contributors, go through the full [Code of Conduct](https://github.com/anitab-org/anitab-forms-backend/blob/develop/CODE_OF_CONDUCT.md)

--- a/.github/workflows/qa-checks.yml
+++ b/.github/workflows/qa-checks.yml
@@ -1,4 +1,4 @@
-name: Open Source Programs QA Checks
+name: AnitaB Forms QA Checks
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)
 [![codecov](https://codecov.io/gh/anitab-org/anitab-forms-backend/branch/develop/graph/badge.svg)](https://codecov.io/gh/anitab-org/anitab-forms-backend)
 
-Open Source Programs (OSP) is an application that simplifies the processing and selection procedure of Open Source Programs of AnitaB.org Open Source or other third-party programs. This is the Backend repo for OSP.
+AnitaB Forms is an application that simplifies the processing and selection procedure of Open Source Programs of AnitaB.org Open Source or other third-party programs. This is the Backend repo for OSP.
 
 ## Tech Stack
 - Django 3.0.7
@@ -228,4 +228,4 @@ Contributions of any kind welcome!
 You can reach the admins, maintainers and our community on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/). If you are interested in contributing to the OSP project, you may join the stream [#anitab-forms](https://anitab-org.zulipchat.com/#narrow/stream/237907-open-source-progs) and ask questions or intereact with the community. Join Us!
 
 ## License
-Open Source Programs Backend is licensed under the GNU General Public License v3.0. To know more about it you can read the [LICENSE](LICENSE).
+AnitaB Forms Backend is licensed under the GNU General Public License v3.0. To know more about it you can read the [LICENSE](LICENSE).

--- a/osp-backend-docusaurus/docs/Home.md
+++ b/osp-backend-docusaurus/docs/Home.md
@@ -4,10 +4,10 @@ title: Home
 slug: /
 ---
 
-Welcome to the **Open Source Programs (Backend)**
+Welcome to the **AnitaB Forms (Backend)**
 
 ## About
-**Open Source Programs** is a project which aims towards simplifying the management work of the mentors and organizations. The goal is to make reviewing and notifying simpler, systematic and manageable. This will help in easy processing and hosting of the Open Source Programs be it a 4-week or a 6-month long program. This was proposed as an [original GSoC'20 project](https://summerofcode.withgoogle.com/archive/2020/organizations/5270382996619264/) by [Bismita Guha](https://github.com/bismitaguha) under the guidance of [Maybelline Burgos](https://github.com/mayburgos), [Monal Shadi](https://github.com/Monal5031), [Abha Wadjikar](https://github.com/abha224) and [Siddharth Venu](https://github.com/sidvenu) as mentors. As the first version of the application, the focus will be on the implementation of the following aspects:
+**AnitaB Forms** is a project which aims towards simplifying the management work of the mentors and organizations. The goal is to make reviewing and notifying simpler, systematic and manageable. This will help in easy processing and hosting of the AnitaB Forms be it a 4-week or a 6-month long program. This was proposed as an [original GSoC'20 project](https://summerofcode.withgoogle.com/archive/2020/organizations/5270382996619264/) by [Bismita Guha](https://github.com/bismitaguha) under the guidance of [Maybelline Burgos](https://github.com/mayburgos), [Monal Shadi](https://github.com/Monal5031), [Abha Wadjikar](https://github.com/abha224) and [Siddharth Venu](https://github.com/sidvenu) as mentors. As the first version of the application, the focus will be on the implementation of the following aspects:
 
 * Building a Minimal Viable Product (MVP) as the first version of the application
 * Digitalize student progress tracking

--- a/osp-backend-docusaurus/docusaurus.config.js
+++ b/osp-backend-docusaurus/docusaurus.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  title: 'Open Source Programs Backend Docs',
-  tagline: 'Documentation for Open Source Programs Backend',
+  title: 'AnitaB Forms Backend Docs',  
+  tagline: 'Documentation for AnitaB Forms Backend',   
   url: 'https://osp-backend-docs.surge.sh/',
   baseUrl: '/',
   onBrokenLinks: 'throw',
@@ -10,7 +10,7 @@ module.exports = {
   projectName: 'osp-backend-docusaurus', // Usually your repo name.
   themeConfig: {
     navbar: {
-      title: 'Open Source Programs Backend',
+      title: 'AnitaB Forms Backend',   
       logo: {
         alt: 'AnitaB.org Logo',
         src: 'img/logo.png',

--- a/osp-backend-docusaurus/src/pages/index.js
+++ b/osp-backend-docusaurus/src/pages/index.js
@@ -12,7 +12,7 @@ function Home() {
   return (
     <Layout
       title={`${siteConfig.title}`}
-      description="Open Source Programs (OSP), an application to process smaller 4-week or full day programs to contribute to open source projects. Similar to GSoC, Outreachy, or RGSoC. This is the backend app.">
+      description="AnitaB Forms, an application to process smaller 4-week or full day programs to contribute to open source projects. Similar to GSoC, Outreachy, or RGSoC. This is the backend app.">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>


### PR DESCRIPTION
### Description
Occurrences of "Open Source Programs" were renamed to "AnitaB Forms" in the docusaurus files, as well as significant markdown and yml files. Following are those files:-
1) docusaurus.config.js 
2) index.js
3) README.md
4) CONTRIBUTING.md
5) Home.md
6) qa-checks.yml              

Fixes #160 

### Type of Change:

- Code
- User Interface
- Documentation

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation